### PR TITLE
Artists site urls fix

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -38,7 +38,7 @@
                     <a class="page-scroll" href="/exhibitions">Exhibitions</a>
                 </li>
                 <li>
-                    <a class="page-scroll" href="/artists">Artists</a>
+                    <a class="page-scroll" href="/artists-list">Artists</a>
                 </li> 
             </ul>
         </div>

--- a/_posts/2016-08-22-artists.markdown
+++ b/_posts/2016-08-22-artists.markdown
@@ -1,16 +1,16 @@
 ---
-title: Made@Eu Artists
+title: Made@Eu Residencies
 showdescription: false
 description: 
 layout: posts
 date: 2014-07-18
-img: residencies.jpg
+img: 
 thumbnail: 
-permalink: /artists
-hasvideo: false
+permalink: /artist-list
+hasvideo: true
 video_embed: https://player.vimeo.com/video/133676785?color=ff9933
-hasgallery1: false   
-gallerytitle: Barcelona Workshops @Green Fab Lab Valldaura
+hasgallery1: true   
+gallerytitle: Barcelona Residency @Fab Lab Barcelona
 images:
   - image_path: /img/residencies/barcelona/residencies-barcelona-nascimento
     title: Batuque, piece by Ricardo O'Nascimento
@@ -24,21 +24,39 @@ images:
     title: Roman Torre 
   - image_path: /img/residencies/barcelona/residencies-barcelona-annemie
     title: Guerrilla Beehives by Annemie Maes 
-hasgallery2: false        
-gallerytitle2:   
+hasgallery2: true        
+gallerytitle2: Plymouth Residency @Plymouth College of Arts   
 images2:
-hasgallery3: false  
-gallerytitle3:   
+  - image_path2: /img/residencies/plymouth/residencies-plymouth-west
+    title: Jack West 
+  - image_path2: /img/residencies/plymouth/residencies-plymouth-smith
+    title: Alfie Smith
+  - image_path2: /img/residencies/plymouth/residencies-plymouth-martinez
+    title: Adriana Martinez
+  - image_path2: /img/residencies/plymouth/residencies-plymouth-ionascu
+    title: Adriana Ionascu
+  - image_path2: /img/residencies/plymouth/residencies-plymouth-bush
+    title: Matthew Bush
+  - image_path2: /img/residencies/plymouth/residencies-plymouth-cuttance
+    title: Phil Cuttance  
+
+hasgallery3: false    
+gallerytitle3:  
 images3:
   - image_path3: 
   - image_path3: 
   - image_path3:    
 ---
 
-{% include mosaic-artists.html %}
+One of the main goals of the Made@Eu Project is the creation of residency programmesfor creative professionals to develop projects that explore the integration of 3-D digital fabrication systems into their processes of design and production, to realize a new outcome. Residencies take place in Barcelona, Paris and Plymouth, facilitating cross-European mobility of creators and generating international opportunities for emerging talent.  
 
+{% include photo-gallery.html %}
 
+The participants selected for the residencies fall within the target group of the Made@EU project, namely designers, craftspeople and artists. They are tasked with the development of a project which represents their background, previous body of work and area of expertise whilst at the same time ingrates the digital fabrication techniques learned at the workshop session offered to them.
 
+Thus, participants are granted access to the digital fabrication equipment available not only at the partners institution where they are located but if required, also to specific equipment available at the facilities of other partners. They also receive continuous guidance and support from the local digital fabrication team as well as experts from the other institutions.
+
+Residencies take place simultaneously in all partner cities, with a duration between 4 and 8 weeks depending on the complexity and ambition of each project.  
 
 
 


### PR DESCRIPTION
can’t give “artists” page the “/artists” because it has a conflict with
the img “/artists” folder. It will be /artists-list form now.
